### PR TITLE
Bugfix/bottom nav bar

### DIFF
--- a/src/__test__/pages/LoginPage.test.tsx
+++ b/src/__test__/pages/LoginPage.test.tsx
@@ -16,8 +16,8 @@ jest.mock("next-auth/react", () => ({
 
 describe("Given a Login page component", () => {
   describe("When it is rendered", () => {
-    test("Then it should show a header with the text 'Welcome to'", () => {
-      const headerText = "Welcome";
+    test("Then it should show a header with the text 'Welcome rider'", () => {
+      const headerText = "Welcome rider";
 
       renderWithProviders(<LoginPage />);
 

--- a/src/components/BottomNavbarWrapper/BottomNavbarWrapper.tsx
+++ b/src/components/BottomNavbarWrapper/BottomNavbarWrapper.tsx
@@ -8,9 +8,13 @@ const BottomNavbarWrapper = (): JSX.Element => {
   const { status } = useSession();
   const isAuthenticated = status === "authenticated";
 
+  if (!isLogged && !isAuthenticated) {
+    return <></>;
+  }
+
   return (
     <BottomNavbarWrapperStyled>
-      {(isLogged || isAuthenticated) && <BottomNavbar />}
+      <BottomNavbar />
     </BottomNavbarWrapperStyled>
   );
 };

--- a/src/components/BottomNavbarWrapper/BottomNavbarWrapper.tsx
+++ b/src/components/BottomNavbarWrapper/BottomNavbarWrapper.tsx
@@ -1,20 +1,16 @@
-import { useRouter } from "next/router";
 import BottomNavbar from "../BottomNavbar/BottomNavbar";
 import BottomNavbarWrapperStyled from "./BottomNavbarWrapperStyled";
-import userEndpoints from "@/utils/userEndpoints/userEndpoints";
+import { useAppSelector } from "@/store/hooks";
+import { useSession } from "next-auth/react";
 
 const BottomNavbarWrapper = (): JSX.Element => {
-  const route = useRouter();
-  if (
-    route.pathname === userEndpoints.login ||
-    route.pathname === userEndpoints.signup
-  ) {
-    return <></>;
-  }
+  const { isLogged } = useAppSelector((state) => state.user);
+  const { status } = useSession();
+  const isAuthenticated = status === "authenticated";
 
   return (
     <BottomNavbarWrapperStyled>
-      <BottomNavbar />
+      {(isLogged || isAuthenticated) && <BottomNavbar />}
     </BottomNavbarWrapperStyled>
   );
 };

--- a/src/components/Layout/Layout.test.tsx
+++ b/src/components/Layout/Layout.test.tsx
@@ -8,6 +8,12 @@ jest.mock("next/router", () => ({
   useRouter: () => mockedUsedRouter,
 }));
 
+const mockedUseSession = jest.fn();
+jest.mock("next-auth/react", () => ({
+  ...jest.requireActual("next-auth/react"),
+  useSession: () => mockedUseSession,
+}));
+
 describe("Given a Layout component", () => {
   describe("When it is rendered", () => {
     test("Then it should show a heading with the text 'Bike'", () => {

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/utils/userFeedback/errorsManager";
 import { useRouter } from "next/navigation";
 import { useAppDispatch } from "@/store/hooks";
+import userEndpoints from "@/utils/userEndpoints/userEndpoints";
 
 const LoginForm = (): JSX.Element => {
   const { loginUser, checkUserIsVerified } = useUser();
@@ -88,7 +89,7 @@ const LoginForm = (): JSX.Element => {
   const { data: session } = useSession();
 
   if (session) {
-    router.push("/home");
+    router.push(`${userEndpoints.home}`);
   }
 
   const areInputFieldsEmpty = email === "" || password === "";
@@ -212,7 +213,7 @@ const LoginForm = (): JSX.Element => {
           </button>
           <div className="login-interface__signup signup">
             <span className="signup__text">Not a member?</span>
-            <Link href="/sign-up" className="signup__link">
+            <Link href={`${userEndpoints.signup}`} className="signup__link">
               Sign up
             </Link>
           </div>

--- a/src/components/RegisterForm/RegisterForm.tsx
+++ b/src/components/RegisterForm/RegisterForm.tsx
@@ -13,6 +13,7 @@ import {
   errorsMessages,
 } from "@/utils/userFeedback/errorsManager";
 import { sucessManagerStatusCodes } from "@/utils/userFeedback/successManager";
+import userEndpoints from "@/utils/userEndpoints/userEndpoints";
 
 const RegisterForm = (): JSX.Element => {
   const { registerUser } = useUser();
@@ -252,7 +253,7 @@ const RegisterForm = (): JSX.Element => {
         </div>
         <div className="register-interface__login login">
           <span className="login__text">Already a member?</span>
-          <Link href="/login" className="login__link">
+          <Link href={`${userEndpoints.login}`} className="login__link">
             Log in
           </Link>
         </div>

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -10,7 +10,7 @@ const LoginPage: NextPage = (): JSX.Element => {
         <div className="heading">
           <div className="heading__welcome">
             <h2 className={`heading__title ${secondaryFont.className}`}>
-              Welcome
+              Welcome rider
             </h2>
           </div>
           <span className={`heading__slogan  ${primaryFont.className}`}>

--- a/src/pages/recovery-email/RecoveryPasswordEmailPageStyled.ts
+++ b/src/pages/recovery-email/RecoveryPasswordEmailPageStyled.ts
@@ -80,6 +80,14 @@ const RecoveryPasswordEmailPageStyled = styled.main`
       font-weight: 900;
     }
   }
+
+  .btn-outline-dark {
+    width: 400px;
+
+    @media (max-width: 450px) {
+      width: 100%;
+    }
+  }
 `;
 
 export default RecoveryPasswordEmailPageStyled;

--- a/src/pages/recovery-email/RecoveryPasswordEmailPageStyled.ts
+++ b/src/pages/recovery-email/RecoveryPasswordEmailPageStyled.ts
@@ -68,6 +68,8 @@ const RecoveryPasswordEmailPageStyled = styled.main`
   }
 
   .modals-messages {
+    height: 40px;
+
     &__error {
       color: #ff0202;
       font-size: 12px;

--- a/src/pages/recovery-email/[validate-email].tsx
+++ b/src/pages/recovery-email/[validate-email].tsx
@@ -14,6 +14,7 @@ import {
 } from "@/utils/userFeedback/successManager";
 import { CircularProgress } from "@mui/material";
 import { useRouter } from "next/navigation";
+import userEndpoints from "@/utils/userEndpoints/userEndpoints";
 
 const RecoveryPasswordEmailPage: NextPage = (): JSX.Element => {
   const { checkUserEmail } = useUser();
@@ -105,7 +106,7 @@ const RecoveryPasswordEmailPage: NextPage = (): JSX.Element => {
         <button
           type="button"
           className="btn btn-outline-dark"
-          onClick={() => route.push("/login")}
+          onClick={() => route.push(`${userEndpoints.login}`)}
         >
           Back to Log in
         </button>

--- a/src/pages/recovery-email/[validate-email].tsx
+++ b/src/pages/recovery-email/[validate-email].tsx
@@ -13,9 +13,11 @@ import {
   sucessManagerStatusCodes,
 } from "@/utils/userFeedback/successManager";
 import { CircularProgress } from "@mui/material";
+import { useRouter } from "next/navigation";
 
 const RecoveryPasswordEmailPage: NextPage = (): JSX.Element => {
   const { checkUserEmail } = useUser();
+  const route = useRouter();
 
   const [email, setEmail] = useState("");
   const [isError, setIsError] = useState("");
@@ -100,6 +102,13 @@ const RecoveryPasswordEmailPage: NextPage = (): JSX.Element => {
             {isSuccess}
           </span>
         </div>
+        <button
+          type="button"
+          className="btn btn-outline-dark"
+          onClick={() => route.push("/login")}
+        >
+          Back to Log in
+        </button>
       </form>
     </RecoveryPasswordEmailPageStyled>
   );

--- a/src/pages/restore-password/[userId].tsx
+++ b/src/pages/restore-password/[userId].tsx
@@ -15,6 +15,7 @@ import {
   successManagerMessages,
   sucessManagerStatusCodes,
 } from "@/utils/userFeedback/successManager";
+import userEndpoints from "@/utils/userEndpoints/userEndpoints";
 
 const RestorePasswordPage: NextPage = (): JSX.Element => {
   const { resetUserPassword } = useUser();
@@ -176,7 +177,7 @@ const RestorePasswordPage: NextPage = (): JSX.Element => {
         <button
           type="button"
           className="btn btn-outline-dark"
-          onClick={() => path.push("/login")}
+          onClick={() => path.push(`${userEndpoints.login}`)}
         >
           Back to Log in
         </button>

--- a/src/pages/verify-email/[confirmationCode].tsx
+++ b/src/pages/verify-email/[confirmationCode].tsx
@@ -7,6 +7,7 @@ import VerifyEmailStyled from "@/pages/verify-email/VerifyEmailStyled";
 import useUser from "@/hooks/useUser/useUser";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
+import userEndpoints from "@/utils/userEndpoints/userEndpoints";
 
 const VerifyEmailPage: NextPage = (): JSX.Element => {
   const { verifyEmail } = useUser();
@@ -42,7 +43,10 @@ const VerifyEmailPage: NextPage = (): JSX.Element => {
         </span>
       </div>
       <button className="verify-page__login">
-        <Link href={"/login"} className={`${primaryFont.className}`}>
+        <Link
+          href={`${userEndpoints.login}`}
+          className={`${primaryFont.className}`}
+        >
           Log in
         </Link>
       </button>

--- a/src/utils/userEndpoints/types/types.ts
+++ b/src/utils/userEndpoints/types/types.ts
@@ -7,4 +7,6 @@ export interface UserEndpointsStructure {
   findUserEmail: string;
   signup: string;
   restorePassword: string;
+  recoveryEmailPassword: string;
+  home: string;
 }

--- a/src/utils/userEndpoints/userEndpoints.ts
+++ b/src/utils/userEndpoints/userEndpoints.ts
@@ -7,8 +7,10 @@ const userEndpoints: UserEndpointsStructure = {
   verifyEmail: "/verify-email",
   getUserIsVerified: "/user-verify",
   findUserEmail: "/recovery-password",
-  signup: "sign-up",
+  signup: "/sign-up",
   restorePassword: "/restore-password/",
+  recoveryEmailPassword: "/recovery-email/validate-email",
+  home: "/home",
 };
 
 export default userEndpoints;


### PR DESCRIPTION
He canviat la manera en la que renderitzem la BottomNavBar en funció del estat isLogged de l'usuari i en funció de si l'usuari te una sessió iniciada amb google o strava. El que passava si ho feiem com ho teniem (en funció del path de la url) era que en pàgines com la recovery-email o recovery-password sortia la navBar i no havia de sortir. Fentho amb l'estat de si l'usuari esta loguejat o no, com és un estat global ja s'aplica a totes les pagines que volem protegir. I fins aquí la meva xapa explicatoria. Salutacions.